### PR TITLE
Add tokens for membership join date

### DIFF
--- a/tokens/latestcurrentmembership.inc
+++ b/tokens/latestcurrentmembership.inc
@@ -7,6 +7,8 @@ function latestcurrentmembership_civitoken_declare($token){
     $token . '.end_date_raw' => 'Latest Current Membership End Date (raw)',
     $token . '.start_date' => 'Latest Current Membership Start Date',
     $token . '.start_date_raw' => 'Latest Current Membership Start Date (raw)',
+    $token . '.join_date' => 'Latest Current Membership Join Date',
+    $token . '.join_date_raw' => 'Latest Current Membership Join Date (raw)',
     $token . '.fee' => 'Latest Current Membership Fee',
     $token . '.status' => 'Latest Current Membership Status',
     $token . '.alltype' => 'Latest Membership Type',
@@ -14,6 +16,8 @@ function latestcurrentmembership_civitoken_declare($token){
     $token . '.allend_date_raw' => 'Latest Membership End Date (raw)',
     $token . '.allstart_date' => 'Latest Membership Start Date',
     $token . '.allstart_date_raw' => 'Latest Membership Start Date (raw)',
+    $token . '.alljoin_date' => 'Latest Membership Join Date',
+    $token . '.alljoin_date_raw' => 'Latest Membership Join Date (raw)',
     $token . '.allfee' => 'Latest Membership Fee',
     $token . '.allstatus' => 'Latest Membership Status',
   );
@@ -50,7 +54,7 @@ function latestcurrentmembership_get_tokens($cid, &$value, $onlyActive) {
     $membership = civicrm_api3('membership', 'getsingle', $params);
   }
   catch (Exception $e) {
-    $tokens = array('type', 'end_date', 'start_date', 'fee', 'status');
+    $tokens = array('type', 'end_date', 'start_date', 'join_date', 'fee', 'status');
     foreach ($tokens as $token) {
       $value['latestcurrentmembership.' . $prefix . $token] = NULL;
     }
@@ -63,6 +67,8 @@ function latestcurrentmembership_get_tokens($cid, &$value, $onlyActive) {
     $value['latestcurrentmembership.' . $prefix . 'end_date_raw'] = !empty($membership['end_date']) ? date('Ymd', strtotime($membership['end_date'])) : '';
     $value['latestcurrentmembership.' . $prefix . 'start_date'] = date('d-m-Y', strtotime($membership['start_date']));
     $value['latestcurrentmembership.' . $prefix . 'start_date_raw'] = date('Ymd', strtotime($membership['start_date']));
+    $value['latestcurrentmembership.' . $prefix . 'join_date'] = date('d-m-Y', strtotime($membership['join_date']));
+    $value['latestcurrentmembership.' . $prefix . 'join_date_raw'] = date('Ymd', strtotime($membership['join_date']));
     $value['latestcurrentmembership.' . $prefix . 'fee'] = $membership['api.membership_type.getsingle']['minimum_fee'];
     $value['latestcurrentmembership.' . $prefix . 'status'] = $statuses[$membership['status_id']];
   }


### PR DESCRIPTION
Thanks for this very helpful extension. I've added some new tokens for my org to display the membership join date and was wondering if you'd like to merge in this feature. I'm pretty new to CiviCRM, so I'm open to any suggested changes.
