### PR TITLE
Fix event api to avoid using filters

### DIFF
--- a/tokens/upcomingevents.inc
+++ b/tokens/upcomingevents.inc
@@ -23,9 +23,10 @@ function upcomingevents_civitoken_declare($token){
  * @param array $value
  */
 function upcomingevents_civitoken_get($cid, &$value) {
+  $curDate = date('Y-m-d');
   $events = civicrm_api3('event', 'get', array(
     'sequential' => 1,
-    'filters' => array('start_date_low' => 'now()'),
+    'start_date' => array('>=' => $curDate),
     'sort' => 'start_date',
     'options' => array('limit' => 1),
   ));
@@ -41,7 +42,7 @@ function upcomingevents_civitoken_get($cid, &$value) {
     'contact_id' => $cid,
     'api.event.get' => array(
       'return' => array('event_type_id', 'summary'),
-      'filters' => array('start_date_low' => 'now()'),
+      'start_date' => array('>=' => $curDate),
     ),
   ));
 


### PR DESCRIPTION
The `get` api of event have removed the dao logic of setting the filter param as per https://github.com/civicrm/civicrm-core/commit/0f3699bfda5e41242cbc43697012140f1fa09ab8#diff-e1827fa25c719ef6968d4fe21589b88aL137. Hence, any param specified in filter is not considered while executing the api which fails the fetching of upcoming events in this tokens. As [dao_set_filter](https://github.com/civicrm/civicrm-core/blob/master/api/v3/utils.php#L626) is already deprecated, modifying the code to use params present in the table.