### PR TITLE
Exclude test contributions and memberships

### DIFF
--- a/tokens/latestcontribs.inc
+++ b/tokens/latestcontribs.inc
@@ -11,6 +11,7 @@ function latestcontribs_civitoken_get($cid, &$value, $context){
   $params = array(
     'sequential' => 1,
     'contact_id' => $cid,
+    'is_test' => 0,
     'options' => array('sort' => "receive_date DESC", 'limit' => 1),
   );
   $softcredit_formatted = "";

--- a/tokens/latestcurrentmembership.inc
+++ b/tokens/latestcurrentmembership.inc
@@ -35,6 +35,7 @@ function latestcurrentmembership_get_tokens($cid, &$value, $onlyActive) {
     'contact_id' => $cid,
     'sequential' => 1,
     'api.membership_type.getsingle' => 1,
+    'is_test' => 0,
     'options' => array('limit' => 1, 'sort' => 'end_date DESC'),
     //'return' => array('membership_end_date', 'end_date', 'start_date', 'status_id', 'minimum_fee', 'membership_name', 'id', 'membership_type_id'),
   );


### PR DESCRIPTION
Exclude test contributions and memberships from the relevant token
collections latestcontribs and latestcurrentmembership.

Related to GitHub issue #13