### PR TITLE
Fix fatal error when using Upcoming events token

### DIFF
--- a/tokens/upcomingevents.inc
+++ b/tokens/upcomingevents.inc
@@ -50,7 +50,8 @@ function upcomingevents_civitoken_get($cid, &$value) {
     return;
   }
   $upcomingEvents = "<table>";
-  $upcomingEventSummaries = $upcomingEventTitles = '';
+  $upcomingEventSummaries = '';
+  $upcomingEventTitles = array();
 
   foreach ($participants['values'] as $particpantID => $participant) {
     if (empty($participant['api.event.get']['values'][0]) || $participant['api.event.get']['values'][0] == 16) {


### PR DESCRIPTION
## Overview
Fixes a fatal error when using any of the Upcoming events tokens.

## Before
A fatal error is thrown:
```
PHP Fatal error:  Uncaught Error: [] operator not supported for strings in
civicrm/ext/nz.co.fuzion.civitoken/tokens/upcomingevents.inc:59
```

## After
Upcoming events token work, no fatal errors.