### PR TITLE
Support tokens folder registered by extensions

### DIFF
--- a/civitoken.php
+++ b/civitoken.php
@@ -229,6 +229,12 @@ function civitoken_initialize() {
         $directories[] = $config->customPHPPathDir . '/tokens';
       }
     }
+    // lookup extension directories
+    foreach (explode(':', get_include_path()) as $path) {
+      if (false !== strpos($path, $config->extensionsDir) && file_exists($path . '/tokens')) {
+        $directories[] = $path;
+      }
+    }
     foreach ($directories as $directory) {
       $tokenFiles = _civitoken_civix_find_files($directory, '*.inc');
       foreach ($tokenFiles as $file) {


### PR DESCRIPTION
## Overview
Allows other extension developers to register/add tokens by adding a `token` directory at the root of the extension directory, just like the existing functionality of adding a `tokens` folder to the CiviCRM's Custom PHP directory. 

## Before
There was no way to register tokens from an extension.

## After
Tokens can be registered from an extension by adding a `tokens` folder in the root of the extension and placing the `.inc` tokens inside the `tokens` folder.
