### PR TITLE
Fix error on contacts with no contributions.

### DIFF
--- a/civitoken.php
+++ b/civitoken.php
@@ -204,11 +204,11 @@ function civitoken_civicrm_tokenValues(&$values, $contactIDs, $job = NULL, $toke
   }
 
   foreach ($tokenFunctions as $token) {
-    if (in_array($token, array_keys($tokens))) {
+    if (array_key_exists($token, $tokens)) {
       $fn = $token . '_civitoken_get';
       foreach ($contactIDs as $contactID) {
         $value =& $values[$contactID];
-        $fn($contactID, $value, $context, $job);
+        $fn($contactID, $value, $context, $job, $tokens[$token]);
       }
     }
   }

--- a/tests/phpunit/CRM/CivitokenTest.php
+++ b/tests/phpunit/CRM/CivitokenTest.php
@@ -109,4 +109,23 @@ class CRM_CivitokenTest extends BaseUnitTestClass implements HeadlessInterface, 
       $this->assertEquals($label . ' : First Name of first contact found', $tokens['relationships']['relationships.first_name_' . $id]);
     }
   }
+
+  /**
+   * Test contribution tokens for a contact with no contributions.
+   *
+   * This tests that regression from https://github.com/eileenmcnaughton/nz.co.fuzion.civitoken/pull/18
+   * whereby an exception was thrown for contact without contributions stays fixed.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testContributionTokenNull() {
+    $contributionTokens = [
+      'latestcontribs.financial_type',
+      'nextpendingcontribution.financial_type',
+    ];
+    $this->callAPISuccess('Setting', 'create', ['civitoken_enabled_tokens' => $contributionTokens]);
+    $this->ids['contact'][0] = $this->callAPISuccess('Contact', 'create', ['contact_type' => 'Individual', 'first_name' => 'bob'])['id'];
+    $values = [];
+    civitoken_civicrm_tokenValues($values, [$this->ids['contact'][0]], NULL, ['latestcontribs' => ['financial_type'], 'nextpendingcontribution' => ['financial_type']]);
+  }
 }

--- a/tokens/latestcontribs.inc
+++ b/tokens/latestcontribs.inc
@@ -10,8 +10,10 @@ function latestcontribs_civitoken_declare($token) {
 }
 
 
-function latestcontribs_civitoken_get($cid, &$value, $context) {
-  $value['latestcontribs.softcredit_name'] = _latestcontribs_soft_credit_name($cid);
+function latestcontribs_civitoken_get($cid, &$value, $context, $job, $tokens) {
+  if (in_array('softcredit_name', $tokens)) {
+    $value['latestcontribs.softcredit_name'] = _latestcontribs_soft_credit_name($cid);
+  }
   $value = _latestcontribs_get_last_completed_contribution($cid, $value);
 
   return $value;

--- a/tokens/nextpendingcontribution.inc
+++ b/tokens/nextpendingcontribution.inc
@@ -15,9 +15,20 @@ function nextpendingcontribution_civitoken_declare($token) {
   ];
 }
 
-
-function nextpendingcontribution_civitoken_get($cid, &$value, $context) {
-  $value['nextpendingcontribution.softcredit_name'] = _nextpendingcontribution_soft_credit_name($cid);
+/**
+ * @param int $cid
+ * @param array $value
+ * @param string $context
+ * @param string $job
+ * @param array $tokens
+ *
+ * @return array
+ * @throws \CiviCRM_API3_Exception
+ */
+function nextpendingcontribution_civitoken_get($cid, &$value, $context, $job, $tokens) {
+  if (in_array('softcredit_name', $tokens)) {
+    $value['nextpendingcontribution.softcredit_name'] = _nextpendingcontribution_soft_credit_name($cid);
+  }
   $value = _nextpendingcontribution_get_next_pending_contribution($cid, $value);
 
   return $value;


### PR DESCRIPTION
Fixes Regression caused by https://github.com/eileenmcnaughton/nz.co.fuzion.civitoken/pull/18 which causes fatal errors on contacts with no contributitons - regardless of whether the new token has been requested

. #18 incorrectly assumes the hook cannot be called if the  contact has no contributions. This fix does not fix that as it would require me to write an appropriate test - it just ensures the new token is not called when it is not required.

It might be  worth fixing for soft credits - but only WITH a test