### PR TITLE
Relationship tokens skip active records when end_date is set

### DIFF
--- a/tokens/relationships.inc
+++ b/tokens/relationships.inc
@@ -80,7 +80,7 @@ function relationships_civitoken_get($cid, &$value) {
     if (!empty($relationship['start_date']) && strtotime($relationship['start_date']) > strtotime('now')) {
       continue;
     }
-    if (!empty($relationship['end_date']) && strtotime($relationship['start_date']) < strtotime('now')) {
+    if (!empty($relationship['end_date']) && strtotime($relationship['end_date']) < strtotime('now')) {
       continue;
     }
     if (!empty($value['relationships.id_' . $relationship['relationship_type_id'] . '_a_b'])) {
@@ -111,7 +111,7 @@ function relationships_civitoken_get($cid, &$value) {
     if (!empty($relationship['start_date']) && strtotime($relationship['start_date']) > strtotime('now')) {
       continue;
     }
-    if (!empty($relationship['end_date']) && strtotime($relationship['start_date']) < strtotime('now')) {
+    if (!empty($relationship['end_date']) && strtotime($relationship['end_date']) < strtotime('now')) {
       continue;
     }
     if (!empty($value['relationships.id_' . $relationship['relationship_type_id'] . '_b_a'])) {


### PR DESCRIPTION
In the relationship token evaluation, active relationships are skipped whenever end_date is present because the expiration check compares start_date instead of end_date.

As a result, tokens like relationships.xxx may return empty values for still-active relationships that have a future end date.
